### PR TITLE
Fix LTE attach issue due to wrong initial attach profile.

### DIFF
--- a/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTracker.java
@@ -1265,10 +1265,9 @@ public class DcTracker extends DcTrackerBase {
         return apn;
     }
 
-    protected ArrayList<ApnSetting> createApnList(Cursor cursor) {
+    protected ArrayList<ApnSetting> createApnList(Cursor cursor, IccRecords r) {
         ArrayList<ApnSetting> mnoApns = new ArrayList<ApnSetting>();
         ArrayList<ApnSetting> mvnoApns = new ArrayList<ApnSetting>();
-        IccRecords r = mIccRecords.get();
 
         if (cursor.moveToFirst()) {
             do {
@@ -2426,7 +2425,7 @@ public class DcTracker extends DcTrackerBase {
 
             if (cursor != null) {
                 if (cursor.getCount() > 0) {
-                    mAllApnSettings = createApnList(cursor);
+                    mAllApnSettings = createApnList(cursor, mIccRecords.get());
                 }
                 cursor.close();
             }
@@ -2446,7 +2445,7 @@ public class DcTracker extends DcTrackerBase {
             // TODO: What is the right behavior?
             //notifyNoData(DataConnection.FailCause.MISSING_UNKNOWN_APN);
         } else {
-            mPreferredApn = getPreferredApn();
+            mPreferredApn = getPreferredApn(mAllApnSettings);
             if (mPreferredApn != null && !mPreferredApn.numeric.equals(operator)) {
                 mPreferredApn = null;
                 setPreferredApn(-1);
@@ -2674,7 +2673,7 @@ public class DcTracker extends DcTrackerBase {
             usePreferred = true;
         }
         if (usePreferred) {
-            mPreferredApn = getPreferredApn();
+            mPreferredApn = getPreferredApn(mAllApnSettings);
         }
         if (DBG) {
             log("buildWaitingApns: usePreferred=" + usePreferred
@@ -2762,9 +2761,9 @@ public class DcTracker extends DcTrackerBase {
         }
     }
 
-    protected ApnSetting getPreferredApn() {
-        if (mAllApnSettings == null || mAllApnSettings.isEmpty()) {
-            log("getPreferredApn: mAllApnSettings is " + ((mAllApnSettings == null)?"null":"empty"));
+    protected ApnSetting getPreferredApn(ArrayList<ApnSetting> apnList) {
+        if (apnList == null || apnList.isEmpty()) {
+            log("getPreferredApn: apnList is " + ((apnList == null)?"null":"empty"));
             return null;
         }
 
@@ -2786,7 +2785,7 @@ public class DcTracker extends DcTrackerBase {
             int pos;
             cursor.moveToFirst();
             pos = cursor.getInt(cursor.getColumnIndexOrThrow(Telephony.Carriers._ID));
-            for(ApnSetting p : mAllApnSettings) {
+            for(ApnSetting p : apnList) {
                 log("getPreferredApn: apnSetting=" + p);
                 if (p.id == pos && p.canHandleType(mRequestedApnType)) {
                     log("getPreferredApn: X found apnSetting" + p);
@@ -2973,7 +2972,7 @@ public class DcTracker extends DcTrackerBase {
         return cid;
     }
 
-    private IccRecords getUiccRecords(int appFamily) {
+    protected IccRecords getUiccRecords(int appFamily) {
         return mUiccController.getIccRecords(mPhone.getPhoneId(), appFamily);
     }
 

--- a/src/java/com/android/internal/telephony/dataconnection/DcTrackerBase.java
+++ b/src/java/com/android/internal/telephony/dataconnection/DcTrackerBase.java
@@ -1784,18 +1784,23 @@ public abstract class DcTrackerBase extends Handler {
     }
 
     protected void setInitialAttachApn() {
+        setInitialAttachApn(mAllApnSettings, mPreferredApn);
+    }
+
+    protected void setInitialAttachApn(ArrayList <ApnSetting> apnList,
+            ApnSetting preferredApn) {
         ApnSetting iaApnSetting = null;
         ApnSetting defaultApnSetting = null;
         ApnSetting firstApnSetting = null;
 
-        log("setInitialApn: E mPreferredApn=" + mPreferredApn);
+        log("setInitialApn: E preferredApn=" + preferredApn);
 
-        if (mAllApnSettings != null && !mAllApnSettings.isEmpty()) {
-            firstApnSetting = mAllApnSettings.get(0);
+        if (apnList != null && !apnList.isEmpty()) {
+            firstApnSetting = apnList.get(0);
             log("setInitialApn: firstApnSetting=" + firstApnSetting);
 
             // Search for Initial APN setting and the first apn that can handle default
-            for (ApnSetting apn : mAllApnSettings) {
+            for (ApnSetting apn : apnList) {
                 // Can't use apn.canHandleType(), as that returns true for APNs that have no type.
                 if (ArrayUtils.contains(apn.types, PhoneConstants.APN_TYPE_IA) &&
                         apn.carrierEnabled) {
@@ -1822,9 +1827,9 @@ public abstract class DcTrackerBase extends Handler {
         if (iaApnSetting != null) {
             if (DBG) log("setInitialAttachApn: using iaApnSetting");
             initialAttachApnSetting = iaApnSetting;
-        } else if (mPreferredApn != null) {
-            if (DBG) log("setInitialAttachApn: using mPreferredApn");
-            initialAttachApnSetting = mPreferredApn;
+        } else if (preferredApn != null) {
+            if (DBG) log("setInitialAttachApn: using preferredApn");
+            initialAttachApnSetting = preferredApn;
         } else if (defaultApnSetting != null) {
             if (DBG) log("setInitialAttachApn: using defaultApnSetting");
             initialAttachApnSetting = defaultApnSetting;


### PR DESCRIPTION
When SIM cards are changed, the attach profile set in modem is
not changed until data is registered. Some times this leads to
permanent LTE attach failure on LTE only networks.
To fix this, de couple set initial attach apn from the setup data call
apn list. Initial attach apn is always queried from 3GPP sim
records as it is applicable only for LTE attach.
DcTracker registers with 3GPP Iccrecords for records loaded event
exclusively for setting initial attach apn.
This makes set initial attach apn operation depend only on sim
records loaded event irrespective of the data registration state.

Change-Id: I4d7b1fe32f7c2ac1b5b0672e7c03bb489d8de596
CRs-Fixed: 936560